### PR TITLE
Build API docs and publish to GitHub Pages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,65 @@
+name: Build and deploy docs
+
+on:
+  push:
+    branches:
+        - master
+  # Allows running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install R
+        uses: r-lib/actions/setup-r@v2
+      - name: Install TinyTeX
+        uses: r-lib/actions/setup-tinytex@v2
+      - name: Install rmarkdown
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+            packages: rmarkdown
+      - name: Build docs
+        run: ./create-api-docs.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: tsd-api-integration*.*
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: docs/
+      - name: Rename HTML file to index.html
+        run: mv docs/tsd-api-integration.html docs/index.html
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Build looks like this: https://github.com/haatveit/tsd-api-docs/actions/runs/8540921938 (faster with cache in place)

Rendered HTML gets hosted on a page like this: https://haatveit.github.io/tsd-api-docs/